### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Login to GitHub Registry
       run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login docker.pkg.github.com --username ${{ secrets.DOCKER_USERNAME }}  --password-stdin
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: docker.pkg.github.com/vergissberlin/andrelademann-de/app
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore